### PR TITLE
Rename missing_fields variable

### DIFF
--- a/src/argus_ticket_jira.py
+++ b/src/argus_ticket_jira.py
@@ -134,7 +134,7 @@ class JiraPlugin(TicketPlugin):
 
         html_body = cls.create_html_body(
             serialized_incident={
-                "__missing_fields__": missing_fields,
+                "missing_fields": missing_fields,
                 **serialized_incident,
             }
         )


### PR DESCRIPTION
Variables in django templates may not begin with an underscore